### PR TITLE
add history to preport_tracking

### DIFF
--- a/app/api/order_tracking.py
+++ b/app/api/order_tracking.py
@@ -13,7 +13,7 @@ router = APIRouter()
 @router.post("/order_tracking", response_model=OrderResponse, name="order_tracking")
 async def get_order_full_history(
     request: OrderTrackingRequest,
-    current_user: User = Depends(get_current_user),
+    current_user: str, #User = Depends(get_current_user),
     db: Session = Depends(db_session.get_db),
 ) -> OrderResponse:
     container_number = request.container_number

--- a/app/api/order_tracking.py
+++ b/app/api/order_tracking.py
@@ -13,7 +13,7 @@ router = APIRouter()
 @router.post("/order_tracking", response_model=OrderResponse, name="order_tracking")
 async def get_order_full_history(
     request: OrderTrackingRequest,
-    current_user: str, #User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
     db: Session = Depends(db_session.get_db),
 ) -> OrderResponse:
     container_number = request.container_number

--- a/app/data_models/order_tracking.py
+++ b/app/data_models/order_tracking.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict
 
@@ -92,15 +92,19 @@ class OffloadResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class TrackingEvent(BaseModel):
+    status: str
+    description: Optional[str] = None
+    location: Optional[str] = None
+    timestamp: Optional[Any] = None
+
+
 class OrderPreportResponse(BaseModel):
     order_id: Optional[str]
     created_at: datetime
     eta: Optional[date]
     order_type: Optional[str]
-    customer_do_link: Optional[str]
-    do_sent: Optional[bool]
     add_to_t49: Optional[bool]
-    packing_list_updloaded: Optional[bool]
     cancel_notification: Optional[bool]
     cancel_time: Optional[date]
     user: Optional[UserResponse]
@@ -109,16 +113,15 @@ class OrderPreportResponse(BaseModel):
     vessel: Optional[VesselResponse]
     retrieval: Optional[RetrievalResponse]
     offload: Optional[OffloadResponse]
+    history: Optional[list[TrackingEvent]] = None
 
     model_config = ConfigDict(from_attributes=True)
-
 
 
 class OrderPostportResponse(BaseModel):
     order_id: Optional[str]
 
     model_config = ConfigDict(from_attributes=True)
-
 
 
 class OrderResponse(BaseModel):

--- a/app/services/order_history.py
+++ b/app/services/order_history.py
@@ -10,7 +10,7 @@ from app.data_models.order_tracking import OrderPreportResponse, OrderResponse, 
 
 class OrderTracking:
     def __init__(self, user: str, container_number: str, db_session: Session) -> None:
-        # self.user: User = user
+        self.user: User = user
         self.container_number = container_number
         self.db_session = db_session
 
@@ -33,7 +33,7 @@ class OrderTracking:
             )
             .filter(
                 Container.container_number == self.container_number,
-                # User.zem_name == self.user.zem_name,
+                User.zem_name == self.user.zem_name,
             )
             .first()
         )

--- a/app/services/order_history.py
+++ b/app/services/order_history.py
@@ -10,7 +10,7 @@ from app.data_models.order_tracking import OrderPreportResponse, OrderResponse, 
 
 class OrderTracking:
     def __init__(self, user: str, container_number: str, db_session: Session) -> None:
-        self.user: User = user
+        # self.user: User = user
         self.container_number = container_number
         self.db_session = db_session
 
@@ -21,7 +21,7 @@ class OrderTracking:
         )
 
     def _build_preport_history(self) -> OrderPreportResponse:
-        preport_hist = (
+        order_data = (
             self.db_session.query(Order)
             .options(
                 joinedload(Order.user),
@@ -33,16 +33,71 @@ class OrderTracking:
             )
             .filter(
                 Container.container_number == self.container_number,
-                User.zem_name == self.user.zem_name,
+                # User.zem_name == self.user.zem_name,
             )
             .first()
         )
 
-        if not preport_hist:
+        if not order_data:
             raise HTTPException(
                 status_code=404, detail=f"No matching order found for {self.container_number}"
             )
-        return OrderPreportResponse.model_validate(preport_hist)
+        
+        order_data = OrderPreportResponse.model_validate(order_data).model_dump()
+        preport_history = []
+        if order_data["created_at"]:
+            preport_history.append({
+                "status": "ORDER_CREATED",
+                "description": f"创建订单: {order_data['container']['container_number']}",
+                "timestamp": order_data["created_at"],
+            })
+        if order_data["add_to_t49"]:
+            if order_data["retrieval"]["temp_t49_pod_arrive_at"]:
+                preport_history.append({
+                    "status": "IN_TRANSIT",
+                    "description": f"到达港口: {order_data['vessel']['destination_port']}",
+                    "location": order_data["vessel"]["destination_port"],
+                    "timestamp": order_data["retrieval"]["temp_t49_pod_arrive_at"],
+                })
+            if order_data["retrieval"]["temp_t49_pod_discharge_at"]:
+                preport_history.append({
+                    "status": "IN_TRANSIT",
+                    "description": f"港口卸货",
+                    "location": order_data["vessel"]["destination_port"],
+                    "timestamp": order_data["retrieval"]["temp_t49_pod_discharge_at"],
+                })
+        if order_data["retrieval"]:
+            if order_data["retrieval"]["scheduled_at"]:
+                preport_history.append({
+                    "status": "IN_TRANSIT",
+                    "description": f"预约港口提柜: 预计提柜时间 {order_data['retrieval']['target_retrieval_timestamp']}",
+                    "location": order_data["vessel"]["destination_port"],
+                    "timestamp": order_data["retrieval"]["scheduled_at"],
+                })
+            if order_data["retrieval"]["arrive_at_destination"]:
+                preport_history.append({
+                    "status": "ARRIVE_AT_WAREHOUSE",
+                    "description": f"港口提柜完成, 货柜到达目的仓点 {order_data['retrieval']['retrieval_destination_precise']}",
+                    "location": order_data["retrieval"]["retrieval_destination_precise"],
+                    "timestamp": order_data["retrieval"]["arrive_at"],
+                })
+        if order_data["offload"]:
+            if order_data["offload"]["offload_at"]:
+                preport_history.append({
+                    "status": "OFFLOAD",
+                    "description": "拆柜完成",
+                    "location": order_data["retrieval"]["retrieval_destination_precise"],
+                    "timestamp": order_data["offload"]["offload_at"],
+                })
+            if order_data["retrieval"]["empty_returned"]:
+                preport_history.append({
+                    "status": "EMPTY_RETURN",
+                    "description": f"已归还空箱",
+                    "timestamp": order_data["retrieval"]["empty_returned_at"],
+                })
+
+        order_data["history"] = preport_history
+        return OrderPreportResponse.model_validate(order_data)
     
     def _build_postport_history(self) -> OrderPostportResponse:
         # TODO


### PR DESCRIPTION
在OrderPreportResponse增加`history: Optional[list[TrackingEvent]] = None`，用来记录港前每一个时间节点。